### PR TITLE
Check for an explicit 'yes' in CO_AVOID_BOX_CHECK

### DIFF
--- a/code/server.coffee
+++ b/code/server.coffee
@@ -100,7 +100,7 @@ check_api_key = (req, res, next) ->
     next()
 
 check_box = (req, res, next) ->
-  if process.env.CO_AVOID_BOX_CHECK
+  if process.env.CO_AVOID_BOX_CHECK == 'yes'
     return next()
   if req.params.boxname?
     Box.findOne {name:req.params.boxname}, (err, box) ->


### PR DESCRIPTION
This fails safe in a nice way. If you typo 'yes' then you'll
get proper box checks, which is probably a good thing.
