### PR TITLE
Remove nibbler and throttler-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "bcrypt": "~0.7.3",
     "ident-express": "~0.0.2",
     "redis": "~0.8.4",
-    "hiredis": "~0.1.15",
-    "throttler-express": "git+https://github.com/scraperwiki/throttler-express.git"
+    "hiredis": "~0.1.15"
   },
   "devDependencies": {
     "mocha": ">=0.4.1",


### PR DESCRIPTION
These are both unused and slow down npm install significantly.
