### PR TITLE
Add libpam script go rewrite

### DIFF
--- a/go/pam_script_ses_open/main.go
+++ b/go/pam_script_ses_open/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	logpkg "log"
 	"log/syslog"
 	"os"
 	"os/exec"
@@ -17,7 +18,13 @@ import (
 const databoxGid = 10000
 
 var pamUser = os.Getenv("PAM_USER")
-var log, _ = syslog.NewLogger(syslog.LOG_WARNING | syslog.LOG_AUTH, 0)
+
+var log *logpkg.Logger
+
+func init() {
+	os.Args[0] = "pam_script_ses_open"
+	log, _ = syslog.NewLogger(syslog.LOG_WARNING|syslog.LOG_AUTH, 0)
+}
 
 func Fatal(first string, args ...interface{}) {
 	// TODO(pwaller): send to syslog?
@@ -132,7 +139,7 @@ func verifyMountNamespace() {
 func main() {
 	start := time.Now()
 	defer func() {
-		log.Println("pam_script_ses_open took", time.Since(start))
+		log.Println("took", time.Since(start))
 	}()
 
 	if !isDataboxUser() {


### PR DESCRIPTION
Preliminary measurements: now takes 100ms on services (an unloaded machine)
where it used to take ~150-200ms. Remains to be seen how well it works on free.

Needs /etc/security/chroot modifying so that the chroot lives at /jail
rather than /jails/%u.

Also needs a bit of other thought for another day.
