### PR TITLE
Automatically gzip responses in cgi-endpoint

### DIFF
--- a/go/daemons/cgi-endpoint/main.go
+++ b/go/daemons/cgi-endpoint/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
+	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/stretchr/graceful"
 )
 
@@ -261,6 +262,7 @@ func NewHandler() http.Handler {
 	box.PathPrefix("/http/").HandlerFunc(HandleHTTP)
 
 	n := negroni.Classic()
+	n.Use(gzip.Gzip(1))
 	n.UseHandler(WrapTokenVerifier(box))
 
 	return n


### PR DESCRIPTION
Uses the cheapest compression possible which gets us the best
bang for the buck I think.

Not tested yet, but I suspect it will be benefitial for odata
and csv.
