### PR TITLE
Remove ScraperWiki branding

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-This software is Copyright (c) 2012 ScraperWiki Limited.
+This software is Copyright (c) 2016 The Sensible Code Company Limited.
 
 Unless otherwise stated in particular files or directories, this
 software is free software; you can redistribute it and/or modify it

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 *This documentation is out of date, as it refers to lithium that we no longer use*
 
-# ScraperWiki Cobalt #
+# QuickCode Cobalt #
 
-Cobalt is a ScraperWiki service where people can run code on the
+Cobalt is a [QuickCode](https://quickcode.io) service where people can run code on the
 internet in
 a sandboxed environment.
 

--- a/code/server.coffee
+++ b/code/server.coffee
@@ -180,7 +180,7 @@ app.post "/:boxname/exec/?", maxInFlightMiddleware(5), check_api_and_box, (req, 
   req.on 'close', -> su.kill()
 
 myCheckIdent = (req, res, next) ->
-  # ScraperWiki office / localhost
+  # Liverpool office / localhost
   if req.ip in [liverpool_office_ip, "10.0.0.10", "127.0.0.1"]
     req.ident = 'root'
     next()

--- a/code/server.coffee
+++ b/code/server.coffee
@@ -133,7 +133,7 @@ fresh_apikey = ->
 
 docs = (req, res) ->
   res.header('Content-Type', 'application/json')
-  res.send "See https://scraperwiki.com/help/developer/", 200
+  res.send "See https://app.quickcode.io/help/developer/", 200
 
 app.get "/", docs
 app.get "/:boxname/?", docs

--- a/go/daemons/cgi-endpoint/main.go
+++ b/go/daemons/cgi-endpoint/main.go
@@ -80,7 +80,7 @@ body {
 <body>
 <h1>404 Not Found</h1>
 <p>Sorry, that dataset does not exist.</p>
-<p>This dataset may have been archived. Please send an email to <a href="mailto:hello@scraperwiki.com">hello@scraperwiki.com</a> if you would like it restored.</p>
+<p>This dataset may have been archived. Please send an email to <a href="mailto:hello@quickcode.io">hello@quickcode.io</a> if you would like it restored.</p>
 </body>
 </html>`
 		w.Header().Set("Content-Type", "text/html")

--- a/http/maintenance.html
+++ b/http/maintenance.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Hmmm… Something’s not right.</title>
-  <meta name="author" content="ScraperWiki Ltd">
+  <meta name="author" content="The Sensible Code Company Ltd">
   <!-- http://t.co/dKP3o1e -->
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">
@@ -38,14 +38,14 @@
 <body>
     <img src="https://scraperwiki.com/image/tractor-500x320.png" width="250" height="160">
     <h1>Maintenance mode</h1>
-    <p class="lead">The ScraperWiki digger is being polished!</p>
+    <p class="lead">The QuickCode digger is being polished!</p>
     <p>
       We've had an unexpected problem we're resolving as quickly as we can. Please check back soon.</p>
     <p>      
-      <a href="https://twitter.com/scraperwiki" class="btn btn-link"><i class="icon-bullhorn"></i>Check Twitter for announcements</a>
+      <a href="https://twitter.com/sensiblecodeio" class="btn btn-link"><i class="icon-bullhorn"></i>Check Twitter for announcements</a>
     </p>
 
-    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/ScraperWiki" data-widget-id="484628273641451520">Tweets by @ScraperWiki</a>
+    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/sensiblecodeio" data-widget-id="484628273641451520">Tweets by @sensiblecodeio</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </body>
 </html>


### PR DESCRIPTION
Replace with QuickCode.

The Twitter change is the only one which could possibly have caused 
problems. Checked the page locally and it loads fine.
